### PR TITLE
Enhance cart editing and store validation

### DIFF
--- a/src/components/ProductEntry.tsx
+++ b/src/components/ProductEntry.tsx
@@ -87,7 +87,14 @@ export default function ProductEntry() {
     };
 
     const handleAdd = () => {
-        if (!name || !price || !currentStoreId) return;
+        if (!name || !price || !currentStoreId || !quantity) return;
+
+        const quantityValue = parseFloat(quantity);
+        const priceValue = parseFloat(price);
+
+        if (Number.isNaN(quantityValue) || Number.isNaN(priceValue) || quantityValue <= 0 || priceValue <= 0) {
+            return;
+        }
 
         let product: Product | undefined = undefined;
 
@@ -109,9 +116,18 @@ export default function ProductEntry() {
             addProduct(product);
         }
 
-        addItem(product, currentStoreId, parseFloat(quantity), parseFloat(price));
+        const unitPrice = isLoose ? priceValue / quantityValue : priceValue;
+
+        addItem(product, currentStoreId, quantityValue, unitPrice);
         handleClose();
     };
+
+    const priceLabel = isLoose ? 'Line Total' : 'Unit Price';
+    const helperText = isLoose
+        ? 'Enter the total from the scale/deli. Unit price will be calculated.'
+        : 'Price per individual unit or package.';
+
+    const isAddDisabled = !name || !price || !quantity || Number(quantity) <= 0 || Number(price) <= 0;
 
     return (
         <Box sx={{ position: 'fixed', bottom: 16, right: 16, left: 16 }}>
@@ -157,7 +173,7 @@ export default function ProductEntry() {
 
                             <Box sx={{ display: 'flex', gap: 2 }}>
                                 <TextField
-                                    label="Price"
+                                    label={priceLabel}
                                     type="number"
                                     value={price}
                                     onChange={(e) => setPrice(e.target.value)}
@@ -165,6 +181,7 @@ export default function ProductEntry() {
                                     InputProps={{
                                         startAdornment: <InputAdornment position="start">$</InputAdornment>,
                                     }}
+                                    helperText={helperText}
                                 />
                                 <TextField
                                     label="Quantity"
@@ -202,7 +219,7 @@ export default function ProductEntry() {
                 </DialogContent>
                 <DialogActions>
                     <Button onClick={handleClose}>Cancel</Button>
-                    <Button onClick={handleAdd} variant="contained" disabled={!name || !price}>
+                    <Button onClick={handleAdd} variant="contained" disabled={isAddDisabled}>
                         Add to Cart
                     </Button>
                 </DialogActions>

--- a/src/store/useReferenceStore.ts
+++ b/src/store/useReferenceStore.ts
@@ -8,6 +8,8 @@ interface ReferenceState {
     setStores: (stores: Store[]) => void;
     setProducts: (products: Product[]) => void;
     addStore: (store: Store) => void;
+    storeExists: (name: string, location: string) => boolean;
+    updateStoreLastUsed: (storeId: string, lastUsed: string) => void;
     addProduct: (product: Product) => void;
     getProductByBarcode: (barcode: string) => Product | undefined;
 }
@@ -22,6 +24,24 @@ export const useReferenceStore = create<ReferenceState>()(
             setProducts: (products) => set({ products }),
 
             addStore: (store) => set((state) => ({ stores: [...state.stores, store] })),
+
+            storeExists: (name, location) => {
+                const normalizedName = name.trim().toLowerCase();
+                const normalizedLocation = location.trim().toLowerCase();
+                return get().stores.some((store) =>
+                    store.StoreName.trim().toLowerCase() === normalizedName &&
+                    store.LocationText.trim().toLowerCase() === normalizedLocation
+                );
+            },
+
+            updateStoreLastUsed: (storeId, lastUsed) => {
+                set((state) => ({
+                    stores: state.stores.map((store) =>
+                        store.StoreID === storeId ? { ...store, LastUsed: lastUsed } : store
+                    ),
+                }));
+            },
+
             addProduct: (product) => set((state) => ({ products: [...state.products, product] })),
 
             getProductByBarcode: (barcode) => {


### PR DESCRIPTION
## Summary
- prevent duplicate stores, capture last-used timestamps, and show validation feedback when adding stores
- support loose-item entry by accepting line totals and computing unit prices, with improved validation
- add an edit dialog for cart items so quantities and prices can be updated while keeping totals in sync

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ef2b00984832ebcdd333c32bb8e91)