### PR TITLE
Use relative base path for PWA hosting

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,9 @@ import { VitePWA } from 'vite-plugin-pwa';
 
 // https://vite.dev/config/
 export default defineConfig({
-  base: '/grocery-companion/',
+  // Use relative asset URLs so the app can be hosted from any bucket folder
+  // (e.g., https://storage.googleapis.com/web-visualisations/grocery-companion/).
+  base: './',
   plugins: [
     react(),
     VitePWA({


### PR DESCRIPTION
## Summary
- switch Vite base path to relative URLs so assets load from nested bucket folders

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f0481f0f4832ebc6cb7679d8d8baf)