### PR TITLE
Reset scan tab when reopening add item dialog

### DIFF
--- a/src/components/ProductEntry.tsx
+++ b/src/components/ProductEntry.tsx
@@ -23,9 +23,13 @@ export default function ProductEntry() {
     const [sizeValue, setSizeValue] = useState('');
     const [sizeUnit, setSizeUnit] = useState('g');
 
-    const handleOpen = () => setOpen(true);
+    const handleOpen = () => {
+        setTabIndex(0);
+        setOpen(true);
+    };
     const handleClose = () => {
         setOpen(false);
+        setTabIndex(0);
         if (scannerRef.current) {
             scannerRef.current.clear().catch(console.error);
             scannerRef.current = null;


### PR DESCRIPTION
## Summary
- reset the Add Item dialog tab to the Scan view whenever it opens or closes
- ensure scanner is reinitialized for each new item without extra clicks

## Testing
- npm run build *(fails: npm missing in environment)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69323e1e73d8832eb4b1f674ffd7f92f)