### PR TITLE
Prefill scanned item prices from purchase history

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -11,7 +11,7 @@ import { api, SyncError } from '../services/api';
 
 export default function Layout() {
     const { currentStoreId, tripId, items, clearCart } = useCartStore();
-    const { stores, setStores, setProducts } = useReferenceStore();
+    const { stores, setStores, setProducts, setLastPrices } = useReferenceStore();
     const [syncing, setSyncing] = useState(false);
     const [health, setHealth] = useState<{ status: 'idle' | 'ok' | 'error', message?: string }>({ status: 'idle' });
     const [snackbar, setSnackbar] = useState<{ open: boolean, message: string, severity: 'success' | 'error' }>({
@@ -45,6 +45,17 @@ export default function Layout() {
                             }));
                             setProducts(normalizedProducts);
                         }
+                        if (data.lastPrices) {
+                            const normalizedPrices = data.lastPrices
+                                .map((p: any) => ({
+                                    storeId: p.StoreID_FK ? String(p.StoreID_FK) : '',
+                                    productId: p.ProductID_FK ? String(p.ProductID_FK) : '',
+                                    unitPrice: Number(p.Unit_Price),
+                                    timestamp: p.Timestamp || ''
+                                }))
+                                .filter((p: any) => p.storeId && p.productId && !Number.isNaN(p.unitPrice));
+                            setLastPrices(normalizedPrices);
+                        }
                     }
                 } catch (fetchErr) {
                     console.warn('Failed to fetch initial data:', fetchErr);
@@ -65,7 +76,7 @@ export default function Layout() {
         return () => {
             active = false;
         };
-    }, [setStores, setProducts]);
+    }, [setStores, setProducts, setLastPrices]);
 
     const handleSync = async () => {
         if (!tripId || !currentStoreId) return;

--- a/src/components/ProductEntry.tsx
+++ b/src/components/ProductEntry.tsx
@@ -8,7 +8,7 @@ import type { Product } from '../types';
 
 export default function ProductEntry() {
     const { addItem, currentStoreId } = useCartStore();
-    const { addProduct, getProductByBarcode, products } = useReferenceStore();
+    const { addProduct, getProductByBarcode, products, getLastPrice, recordLastPrice } = useReferenceStore();
 
     const [open, setOpen] = useState(false);
     const [tabIndex, setTabIndex] = useState(0); // 0 = Scan, 1 = Manual
@@ -22,10 +22,16 @@ export default function ProductEntry() {
     const [isLoose, setIsLoose] = useState(false);
     const [sizeValue, setSizeValue] = useState('');
     const [sizeUnit, setSizeUnit] = useState('g');
+    const [lastKnownPrice, setLastKnownPrice] = useState<number | null>(null);
+    const [lastKnownTimestamp, setLastKnownTimestamp] = useState<string | null>(null);
 
-    const handleOpen = () => setOpen(true);
+    const handleOpen = () => {
+        setTabIndex(0);
+        setOpen(true);
+    };
     const handleClose = () => {
         setOpen(false);
+        setTabIndex(0);
         if (scannerRef.current) {
             scannerRef.current.clear().catch(console.error);
             scannerRef.current = null;
@@ -41,23 +47,42 @@ export default function ProductEntry() {
         setIsLoose(false);
         setSizeValue('');
         setSizeUnit('g');
+        setLastKnownPrice(null);
+        setLastKnownTimestamp(null);
     };
 
     const onScanSuccess = useCallback((decodedText: string) => {
         setBarcode(decodedText);
+        setLastKnownPrice(null);
+        setLastKnownTimestamp(null);
         const existingProduct = getProductByBarcode(decodedText);
         if (existingProduct) {
             setName(existingProduct.Name);
             setIsLoose(existingProduct.IsLoose);
             setSizeValue(existingProduct.SizeValue?.toString() || '');
             setSizeUnit(existingProduct.SizeUnit || 'g');
+
+            if (currentStoreId) {
+                const lastPrice = getLastPrice(currentStoreId, existingProduct.ProductID);
+                if (lastPrice) {
+                    setPrice(lastPrice.unitPrice.toString());
+                    setLastKnownPrice(lastPrice.unitPrice);
+                    setLastKnownTimestamp(lastPrice.timestamp);
+                } else {
+                    setLastKnownPrice(null);
+                    setLastKnownTimestamp(null);
+                }
+            }
+        } else {
+            setLastKnownPrice(null);
+            setLastKnownTimestamp(null);
         }
         setTabIndex(1); // Switch to manual/confirm view
         if (scannerRef.current) {
             scannerRef.current.clear().catch(console.error);
             scannerRef.current = null;
         }
-    }, [getProductByBarcode]);
+    }, [currentStoreId, getLastPrice, getProductByBarcode]);
 
     const onScanFailure = useCallback(() => {
         // Silently ignore scan failures
@@ -133,6 +158,7 @@ export default function ProductEntry() {
         const unitPrice = isLoose ? priceValue / quantityValue : priceValue;
 
         addItem(product, currentStoreId, quantityValue, unitPrice);
+        recordLastPrice(currentStoreId, product.ProductID, unitPrice, new Date().toISOString());
         handleClose();
     };
 
@@ -140,6 +166,10 @@ export default function ProductEntry() {
     const helperText = isLoose
         ? 'Enter the total from the scale/deli. Unit price will be calculated.'
         : 'Price per individual unit or package.';
+
+    const formattedLastSeen = lastKnownTimestamp && !Number.isNaN(new Date(lastKnownTimestamp).getTime())
+        ? new Date(lastKnownTimestamp).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })
+        : null;
 
     const isAddDisabled = !name || !price || !quantity || Number(quantity) <= 0 || Number(price) <= 0;
 
@@ -214,6 +244,12 @@ export default function ProductEntry() {
                                     fullWidth
                                 />
                             </Box>
+
+                            {lastKnownPrice !== null && (
+                                <Typography variant="caption" color="text.secondary">
+                                    Last seen price: ${lastKnownPrice.toFixed(2)}{formattedLastSeen ? ` on ${formattedLastSeen}` : ''}
+                                </Typography>
+                            )}
 
                             <FormControlLabel
                                 control={<Switch checked={isLoose} onChange={(e) => setIsLoose(e.target.checked)} />}

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,13 @@ export interface CartItem {
   lineTotal: number;
 }
 
+export interface LastPriceSnapshot {
+  storeId: string;
+  productId: string;
+  unitPrice: number;
+  timestamp: string;
+}
+
 export interface PurchaseLog {
   LogID?: string;
   TripID: string;


### PR DESCRIPTION
## Summary
- expose last-known unit prices per store/product via the Purchase_History sheet in the Apps Script API
- persist last price snapshots in the reference store and prefill scanned items with the most recent price
- show last seen price details alongside the price input when a match is found

## Testing
- npm run lint *(fails: npm not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69323e1e73d8832eb4b1f674ffd7f92f)